### PR TITLE
Enable streaming dataset loading

### DIFF
--- a/docs/fine-tuning-gotchas.md
+++ b/docs/fine-tuning-gotchas.md
@@ -104,3 +104,10 @@ If your loss plateaus or doesn't decrease:
 1. Check your learning rate (try reducing by 10x)
 2. Ensure your data is properly formatted
 3. Verify the model is actually learning your examples (not just the template)
+
+## Working with Large Datasets
+
+Fine-tuning jobs now stream training data line by line.  Place your JSONL files
+on local storage and ROSE will build an Arrow dataset in the background without
+loading the entire file into memory.  This keeps RAM usage low, but requires
+enough disk space for the temporary cache.


### PR DESCRIPTION
## Summary
- allow `_load_jsonl` to stream JSONL files
- build dataset from generator in `_prepare_dataset`
- document large dataset advice for fine-tuning

## Testing
- `ruff check .`
- `pytest -o addopts="" -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cbe56dac8330b9be2ec7e9e141f6