### PR TITLE
Prime psutil measurement in hardware monitor

### DIFF
--- a/src/rose_finetune/training/callbacks/hardware_monitor.py
+++ b/src/rose_finetune/training/callbacks/hardware_monitor.py
@@ -13,9 +13,9 @@ class HardwareMonitorCallback(_BaseCallback):
 
     def __init__(self, event_cb=None) -> None:
         super().__init__(event_cb)
-        self._process = psutil.Process()
 
     def on_train_begin(self, args, state, control, **_):
+        self._process = psutil.Process()
         self._process.cpu_percent(None)
 
     def on_log(self, args, state, control, logs=None, **_):

--- a/src/rose_finetune/training/callbacks/hardware_monitor.py
+++ b/src/rose_finetune/training/callbacks/hardware_monitor.py
@@ -11,6 +11,13 @@ logger = logging.getLogger(__name__)
 class HardwareMonitorCallback(_BaseCallback):
     """Simple hardware monitoring callback."""
 
+    def __init__(self, event_cb=None) -> None:
+        super().__init__(event_cb)
+        self._process = psutil.Process()
+
+    def on_train_begin(self, args, state, control, **_):
+        self._process.cpu_percent(None)
+
     def on_log(self, args, state, control, logs=None, **_):
         if not logs or state.global_step % 10 != 0:
             return
@@ -26,8 +33,7 @@ class HardwareMonitorCallback(_BaseCallback):
             except Exception:
                 pass
 
-        process = psutil.Process()
-        metrics["cpu_percent"] = process.cpu_percent()
-        metrics["ram_gb"] = round(process.memory_info().rss / 1024**3, 2)
+        metrics["cpu_percent"] = self._process.cpu_percent()
+        metrics["ram_gb"] = round(self._process.memory_info().rss / 1024**3, 2)
 
         self._send("debug", "Hardware metrics", metrics)

--- a/src/rose_finetune/training/callbacks/hardware_monitor.py
+++ b/src/rose_finetune/training/callbacks/hardware_monitor.py
@@ -13,6 +13,7 @@ class HardwareMonitorCallback(_BaseCallback):
 
     def __init__(self, event_cb=None) -> None:
         super().__init__(event_cb)
+        self._process = None  # Initialize to None to avoid AttributeError
 
     def on_train_begin(self, args, state, control, **_):
         self._process = psutil.Process()


### PR DESCRIPTION
## Summary
- prime CPU percent measurement on training start
- reuse a single `psutil.Process` instance for repeated metrics

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6854cbf252208330b17df3cb44f9260a