### PR TITLE
Add utils failure tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import sys
+sys.path.append('src')
+
+from rose_server import utils
+
+
+def test_extract_user_content_returns_none_for_invalid_type():
+    assert utils.extract_user_content(123) is None
+
+
+def test_extract_user_content_returns_none_when_no_input_text():
+    content = [{"type": "image", "url": "image.png"}]
+    assert utils.extract_user_content(content) is None
+


### PR DESCRIPTION
## Summary
- cover failure cases for `extract_user_content`
- remove previous service registry tests

## Testing
- `pytest --override-ini addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68555bb031848330b9c2a02fd374e547